### PR TITLE
Set dependencies' versions to fixed

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,19 +46,19 @@
         <dependency>
             <groupId>com.mscharhag.oleaster</groupId>
             <artifactId>oleaster-matcher</artifactId>
-            <version>RELEASE</version>
+            <version>0.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>RELEASE</version>
+            <version>[4.12,)</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-all</artifactId>
-            <version>RELEASE</version>
+            <version>[1.10,)</version>
             <scope>test</scope>
         </dependency>
     </dependencies>


### PR DESCRIPTION
It's because "RELEASE" keyword is deprecated.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmemkv-java/33)
<!-- Reviewable:end -->
