### PR TITLE
Remove asserting error msg from tests.

### DIFF
--- a/src/test/java/io/pmem/pmemkv/tests/DatabaseTest.java
+++ b/src/test/java/io/pmem/pmemkv/tests/DatabaseTest.java
@@ -237,7 +237,6 @@ public class DatabaseTest {
             Assert.fail();
         } catch (DatabaseException kve) {
             expect(kve.getKey()).toBeNull();
-            expect(kve.getMessage()).toEqual("Failed to open pmemkv"); // XXX
         } catch (Exception e) {
             Assert.fail();
         }
@@ -252,7 +251,6 @@ public class DatabaseTest {
             Assert.fail();
         } catch (DatabaseException kve) {
             expect(kve.getKey()).toBeNull();
-            expect(kve.getMessage()).toEqual("JSON parsing error"); // XXX
         } catch (Exception e) {
             Assert.fail();
         }
@@ -267,7 +265,6 @@ public class DatabaseTest {
             Assert.fail();
         } catch (DatabaseException kve) {
             expect(kve.getKey()).toBeNull();
-            expect(kve.getMessage()).toEqual("Failed to open pmemkv"); // XXX
         } catch (Exception e) {
             Assert.fail();
         }
@@ -282,7 +279,6 @@ public class DatabaseTest {
             Assert.fail();
         } catch (DatabaseException kve) {
             expect(kve.getKey()).toBeNull();
-            expect(kve.getMessage()).toEqual("Failed to open pmemkv"); // XXX
         } catch (Exception e) {
             Assert.fail();
         }
@@ -297,7 +293,6 @@ public class DatabaseTest {
             Assert.fail();
         } catch (DatabaseException kve) {
             expect(kve.getKey()).toBeNull();
-            expect(kve.getMessage()).toEqual("Failed to open pmemkv"); // XXX
         } catch (Exception e) {
             Assert.fail();
         }

--- a/utils/docker/images/install-dependencies.sh
+++ b/utils/docker/images/install-dependencies.sh
@@ -40,8 +40,8 @@ set -e
 # package manager: DEB or RPM
 PACKAGE_MANAGER=$1
 
-# Merge pull request #30 from ldorau/Fixes-after-review, 30.10.2019
-JNI_VERSION="41499c7f3bdc16459bf73d458049f81084d64001"
+# Merge pull request #34 from igchor/add_pmemkv_errormsg, 06.12.2019
+JNI_VERSION="fcc8370b230ab3236d062a121e22dcebf37b90ec"
 
 # add ChangeLog 0.9, 4.10.2019
 JAVA_VERSION="0.9"


### PR DESCRIPTION
This is needed for pmemkv-java tests to pass after:
https://github.com/pmem/pmemkv-jni/pull/34

We do not guarantee stability of error messages so let's remove
the checks.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmemkv-java/36)
<!-- Reviewable:end -->
