### PR TITLE
set utf-8 encoding for tests in pom file

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,11 +25,10 @@ Start by installing [pmemkv](https://github.com/pmem/pmemkv/blob/master/INSTALLI
 (currently at least in version **1.0.2**) in your system.
 
 It may be necessary to [configure a proxy](https://maven.apache.org/guides/mini/guide-proxies.html)
-and set `JAVA_HOME` & `JAVA_TOOL_OPTIONS` environment variables:
+and set `JAVA_HOME` environment variable:
 
 ```sh
 export JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64
-export JAVA_TOOL_OPTIONS=-Dfile.encoding=UTF-8
 ```
 
 Clone the pmemkv-java tree:

--- a/src/main/pom.xml
+++ b/src/main/pom.xml
@@ -36,7 +36,7 @@
                 <version>2.22.1</version>
                 <configuration>
                     <useSystemClassLoader>false</useSystemClassLoader>
-                    <argLine>-Djava.library.path=${project.build.directory}/classes</argLine>
+                    <argLine>-Djava.library.path=${project.build.directory}/classes -Dfile.encoding=UTF-8</argLine>
                 </configuration>
             </plugin>
             <plugin>

--- a/utils/docker/images/Dockerfile.fedora-32
+++ b/utils/docker/images/Dockerfile.fedora-32
@@ -4,6 +4,7 @@
 #
 # Dockerfile - a 'recipe' for Docker to build an image of fedora-based
 #              environment prepared for running pmemkv-java build and tests.
+#
 
 # Pull base image
 FROM fedora:32
@@ -15,7 +16,6 @@ ENV OS_VER 32
 ENV PACKAGE_MANAGER rpm
 ENV NOTTY 1
 ENV JAVA_HOME /usr/lib/jvm/java-openjdk/
-ENV JAVA_TOOL_OPTIONS -Dfile.encoding=UTF-8
 
 # Additional parameters to build docker without building components
 ARG SKIP_PMDK_BUILD

--- a/utils/docker/images/Dockerfile.ubuntu-20.04
+++ b/utils/docker/images/Dockerfile.ubuntu-20.04
@@ -16,7 +16,6 @@ ENV OS_VER 20.04
 ENV PACKAGE_MANAGER deb
 ENV NOTTY 1
 ENV JAVA_HOME /usr/lib/jvm/java-11-openjdk-amd64
-ENV JAVA_TOOL_OPTIONS -Dfile.encoding=UTF-8
 
 # Additional parameters to build docker without building components
 ARG SKIP_PMDK_BUILD


### PR DESCRIPTION
so we don't need env. variable in docker images (and in README).

ref. #14

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmemkv-java/66)
<!-- Reviewable:end -->
