### PR TITLE
it seems libpmemkv-jni is not required as dependency for java module

### DIFF
--- a/src/main/pom.xml
+++ b/src/main/pom.xml
@@ -85,13 +85,6 @@
 
     <dependencies>
         <dependency>
-            <groupId>io.pmem</groupId>
-            <artifactId>libpmemkv-jni</artifactId>
-            <version>1.0.0</version>
-            <scope>runtime</scope>
-            <type>so</type>
-        </dependency>
-        <dependency>
             <groupId>com.mscharhag.oleaster</groupId>
             <artifactId>oleaster-matcher</artifactId>
             <version>0.2.0</version>


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmemkv-java/86)
<!-- Reviewable:end -->
