### PR TITLE
docker: go-offline with test dependencies, too

### DIFF
--- a/utils/docker/images/install-dependencies.sh
+++ b/utils/docker/images/install-dependencies.sh
@@ -48,7 +48,7 @@ deps_dir=$(mktemp -d)
 git clone https://github.com/pmem/pmemkv-java.git ${deps_dir}
 pushd ${deps_dir}
 git checkout $JAVA_VERSION
-mvn install -Dmaven.test.skip=true
+mvn install
 mvn dependency:go-offline
 mv -v ~/.m2/repository /opt/java/
 


### PR DESCRIPTION
Right now, since tests are skipped, not all tests' dependencies
are installed. Since our tests don't last long, we can enable them.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmemkv-java/91)
<!-- Reviewable:end -->
