### PR TITLE
utils: correct path to generated documentation for javadoc

### DIFF
--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -49,5 +49,6 @@
         <maven.compiler.target>1.8</maven.compiler.target>
         <maven.compiler.encoding>UTF-8</maven.compiler.encoding>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <maven.javadoc.skip>true</maven.javadoc.skip>
     </properties>
 </project>

--- a/pmemkv-binding/pom.xml
+++ b/pmemkv-binding/pom.xml
@@ -47,11 +47,6 @@
 				</configuration>
 			</plugin>
 			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-javadoc-plugin</artifactId>
-				<version>3.0.0</version>
-			</plugin>
-			<plugin>
 				<groupId>net.revelc.code.formatter</groupId>
 				<artifactId>formatter-maven-plugin</artifactId>
 				<version>2.11.0</version>

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
     <url>https://github.com/pmem/pmemkv-java</url>
     <packaging>pom</packaging>
 
-	<properties>
+    <properties>
         <!-- use Java in ver. 8 and UTF-8 encoding -->
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
@@ -25,28 +25,33 @@
         <module>examples</module> <!-- pom for java examples part -->
     </modules>
 
-     <build>
-      <plugins>
-        <plugin>
-          <groupId>net.revelc.code.formatter</groupId>
-          <artifactId>formatter-maven-plugin</artifactId>
-          <version>2.11.0</version>
-          <configuration>
-            <configFile>${pom.basedir}/utils/eclipse-formatter-config.xml</configFile>
-            <lineEnding>LF</lineEnding>
-          </configuration>
-          <executions>
-            <execution>
-              <goals>
-                <goal>validate</goal>
-              </goals>
-            </execution>
-          </executions>
-        </plugin>
-      </plugins>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>net.revelc.code.formatter</groupId>
+                <artifactId>formatter-maven-plugin</artifactId>
+                <version>2.11.0</version>
+                <configuration>
+                    <configFile>${pom.basedir}/utils/eclipse-formatter-config.xml</configFile>
+                    <lineEnding>LF</lineEnding>
+                </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>validate</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <version>3.2.0</version>
+            </plugin>
+        </plugins>
     </build>
 
-     <issueManagement>
+    <issueManagement>
         <system>GitHub</system>
         <url>https://github.com/pmem/pmemkv-java/issues</url>
     </issueManagement>

--- a/utils/docker/run-doc-update.sh
+++ b/utils/docker/run-doc-update.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright 2018-2020, Intel Corporation
+# Copyright 2018-2021, Intel Corporation
 
 #
 # run-doc-update.sh - is called inside a Docker container,
@@ -41,7 +41,7 @@ git checkout -B ${TARGET_BRANCH} upstream/${TARGET_BRANCH}
 
 # Build docs
 mvn javadoc:javadoc -e
-cp -r $CURR_DIR/pmemkv-java/src/main/target/site/apidocs $CURR_DIR/
+cp -r $CURR_DIR/pmemkv-java/target/site/apidocs $CURR_DIR/
 
 # Checkout gh-pages and copy docs
 GH_PAGES_NAME="gh-pages-for-${TARGET_BRANCH}"


### PR DESCRIPTION
Previous approach cause generation of documentation separately for each project module.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmemkv-java/104)
<!-- Reviewable:end -->
