### PR TITLE
docker: install binding before executing javadoc

### DIFF
--- a/utils/docker/run-doc-update.sh
+++ b/utils/docker/run-doc-update.sh
@@ -58,6 +58,7 @@ git remote update
 git checkout -B ${TARGET_BRANCH} upstream/${TARGET_BRANCH}
 
 echo "Build docs:"
+mvn install -Dmaven.test.skip=true -e
 mvn javadoc:javadoc -e
 cp -r ${REPO_DIR}/pmemkv-binding/target/site/apidocs ${ARTIFACTS_DIR}/
 


### PR DESCRIPTION
mea culpa; since the doc job is separated it should be installed in the system before we run `javadoc` goal

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmemkv-java/123)
<!-- Reviewable:end -->
