### PR TITLE
[java] fix finalize crash

### DIFF
--- a/jni-binding/io_pmem_pmemkv_Database.cpp
+++ b/jni-binding/io_pmem_pmemkv_Database.cpp
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-/* Copyright 2017-2020, Intel Corporation */
+/* Copyright 2017-2021, Intel Corporation */
 
 #include <cstring>
 #include <string>
@@ -66,12 +66,11 @@ extern "C" JNIEXPORT jlong JNICALL Java_io_pmem_pmemkv_Database_database_1start
 
     pmemkv_db *db;
     auto status = pmemkv_open(cengine, (pmemkv_config*) config, &db);
-
     env->ReleaseStringUTFChars(engine, cengine);
 
-    if (status != PMEMKV_STATUS_OK)
+    if (status != PMEMKV_STATUS_OK) {
             PmemkvJavaException(env).ThrowException(status);
-
+    }
     return (jlong) db;
 }
 
@@ -98,8 +97,8 @@ struct Context {
 
 void Callback_get_value_buffer(const char* v, size_t vb, void *arg) {
     const auto c = static_cast<Context*>(arg);
-    // OutOfMemoryError may Occurr
-    if( jobject valuebuf = c->env->NewDirectByteBuffer(const_cast<char*>(v), vb)) {
+    // OutOfMemoryError may occurr
+    if (jobject valuebuf = c->env->NewDirectByteBuffer(const_cast<char*>(v), vb)) {
         // Rerise exception
         c->env->CallVoidMethod(c->callback, c->mid, vb, valuebuf);
         c->env->DeleteLocalRef(valuebuf);
@@ -109,7 +108,7 @@ void Callback_get_value_buffer(const char* v, size_t vb, void *arg) {
 int Callback_get_keys_buffer(const char* k, size_t kb, const char* v, size_t vb, void *arg) {
     const auto c = static_cast<Context*>(arg);
     Callback_get_value_buffer(k, kb, arg);
-    if( c->env->ExceptionOccurred()) {
+    if (c->env->ExceptionOccurred()) {
         return 1;
     }
     return 0;

--- a/jni-binding/io_pmem_pmemkv_Database_Builder.cpp
+++ b/jni-binding/io_pmem_pmemkv_Database_Builder.cpp
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-/* Copyright 2020, Intel Corporation */
+/* Copyright 2021, Intel Corporation */
 
 #include <jni.h>
 #include <libpmemkv.h>
@@ -13,19 +13,17 @@ extern "C" JNIEXPORT jlong JNICALL Java_io_pmem_pmemkv_Database_00024Builder_con
         env->ThrowNew(env->FindClass(EXCEPTION_CLASS), pmemkv_errormsg());
         return 0;
     }
-
     return (jlong) cfg;
 }
 
 extern "C" JNIEXPORT void JNICALL Java_io_pmem_pmemkv_Database_00024Builder_config_1delete
-  (JNIEnv *, jobject cfg){
+  (JNIEnv *, jobject, jlong cfg) {
     pmemkv_config_delete((pmemkv_config *) cfg);
 }
 
 extern "C" JNIEXPORT void JNICALL Java_io_pmem_pmemkv_Database_00024Builder_config_1put_1int
-  (JNIEnv *env, jobject, jlong cfg, jstring jkey, jlong value){
+  (JNIEnv *env, jobject, jlong cfg, jstring jkey, jlong value) {
     const char* key = env->GetStringUTFChars(jkey, NULL);
-
     auto status = pmemkv_config_put_int64((pmemkv_config *) cfg, key, (int64_t) value);
     if (status != PMEMKV_STATUS_OK)
       env->ThrowNew(env->FindClass(EXCEPTION_CLASS), pmemkv_errormsg());
@@ -34,7 +32,7 @@ extern "C" JNIEXPORT void JNICALL Java_io_pmem_pmemkv_Database_00024Builder_conf
 }
 
 extern "C" JNIEXPORT void JNICALL Java_io_pmem_pmemkv_Database_00024Builder_config_1put_1string
-  (JNIEnv *env, jobject, jlong cfg, jstring jkey, jstring jvalue){
+  (JNIEnv *env, jobject, jlong cfg, jstring jkey, jstring jvalue) {
     const char* key = env->GetStringUTFChars(jkey, NULL);
     const char* value = env->GetStringUTFChars(jvalue, NULL);
 

--- a/pmemkv-binding/src/main/java/io/pmem/pmemkv/Database.java
+++ b/pmemkv-binding/src/main/java/io/pmem/pmemkv/Database.java
@@ -396,15 +396,6 @@ public class Database<K, V> {
 		return database_remove_buffer(pointer, direct_key.position(), direct_key);
 	}
 
-	private Database(Builder<K, V> builder) {
-		keyConverter = builder.keyConverter;
-		valueConverter = builder.valueConverter;
-		pointer = database_start(builder.engine, builder.config);
-	}
-
-	private final long pointer;
-	private boolean stopped;
-
 	/**
 	 * Builder is used to build instances of pmemkv Database class.
 	 * <p>
@@ -424,10 +415,12 @@ public class Database<K, V> {
 
 		public Builder(String engine) {
 			config = config_new();
-
 			this.engine = engine;
 		}
 
+		/**
+		 * Frees underlying resources.
+		 */
 		@Override
 		public void finalize() {
 			if (config != 0) {
@@ -442,7 +435,6 @@ public class Database<K, V> {
 		 * @param size
 		 *            size of the pmemkv datastore.
 		 * @return this builder object.
-		 *
 		 */
 		public Builder<K, V> setSize(long size) {
 			config_put_int(config, "size", size);
@@ -480,12 +472,8 @@ public class Database<K, V> {
 		 * @return instance of pmemkv Database.
 		 */
 		public Database<K, V> build() {
-			Database<K, V> db = new Database<K, V>(this);
-
-			/* After open, db takes ownership of the config */
-			config = 0;
-
-			return db;
+			/* Engine takes config's ownership */
+			return new Database<K, V>(this);
 		}
 
 		/**
@@ -571,6 +559,17 @@ public class Database<K, V> {
 			}
 		}
 	}
+
+	private Database(Builder<K, V> builder) {
+		keyConverter = builder.keyConverter;
+		valueConverter = builder.valueConverter;
+		long config = builder.config;
+		builder.config = 0;
+		pointer = database_start(builder.engine, config);
+	}
+
+	private final long pointer;
+	private boolean stopped;
 
 	// JNI DATABASE METHODS
 	// --------------------------------------------------------------------------------


### PR DESCRIPTION
I was tested many cases and after few hours I decided to remove finalize() method.
First of all, I don't know how unique_pointer treat passed config, but please take a look for a following:
1. We invoke Builder->build()
2. new Database() object is now creating
3. database_start() is invoked with pmemkv_open() under the hood (this fails). First thing it does is to wrap config with unique_pointer.
4. Previously: finalize() tried to free config.

I'm planning to rewrite pmemkv internals responsible for creating engines and then more control about resources will be achieved.
Would be good to have config reusable, then only additional parameter would be set when opening/creating failed, but generally it's now impossible due to destroing config on pmemkv side.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmemkv-java/130)
<!-- Reviewable:end -->
