### PR TITLE
utils: fix setup-maven-settings.sh

### DIFF
--- a/utils/docker/images/setup-maven-settings.sh
+++ b/utils/docker/images/setup-maven-settings.sh
@@ -9,8 +9,6 @@
 #			these extra params for run-*.sh scripts.
 #
 
-set -e
-
 # Split proxies into host & port; remove possible leftover "/"
 if [[ -n "${http_proxy}" ]]; then
 	http_proxy_ip=$(echo ${http_proxy} | cut -d: -f2 | sed 's/\///g')


### PR DESCRIPTION
since this script may be sourced in user's shell it should not specify -e option.
set -e is specified in install-dependencies.sh (where we use this script) anyway.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmemkv-java/132)
<!-- Reviewable:end -->
