### PR TITLE
Fix exceptions in jni

### DIFF
--- a/jni-binding/io_pmem_pmemkv_Database.cpp
+++ b/jni-binding/io_pmem_pmemkv_Database.cpp
@@ -116,16 +116,16 @@ int Callback_get_keys_buffer(const char* k, size_t kb, const char* v, size_t vb,
 extern "C" JNIEXPORT void JNICALL Java_io_pmem_pmemkv_Database_database_1get_1keys_1buffer
         (JNIEnv* env, jobject obj, jlong pointer, jobject callback) {
     auto engine = (pmemkv_db*) pointer;
-    auto cxt = Context(env, callback,  METHOD_GET_KEYS_BUFFER);
+    auto cxt = Context(env, callback, METHOD_GET_KEYS_BUFFER);
     auto status = pmemkv_get_all(engine, Callback_get_keys_buffer, &cxt);
-    if (status != PMEMKV_STATUS_OK)PmemkvJavaException(env).ThrowException(status);
+    if (status != PMEMKV_STATUS_OK) PmemkvJavaException(env).ThrowException(status);
 }
 
 extern "C" JNIEXPORT void JNICALL Java_io_pmem_pmemkv_Database_database_1get_1keys_1above_1buffer
         (JNIEnv* env, jobject obj, jlong pointer, jint keybytes, jobject key, jobject callback) {
     auto engine = (pmemkv_db*) pointer;
     const char* ckey = (char*) env->GetDirectBufferAddress(key);
-    auto cxt = Context(env, callback,  METHOD_GET_KEYS_BUFFER);
+    auto cxt = Context(env, callback, METHOD_GET_KEYS_BUFFER);
     auto status = pmemkv_get_above(engine, ckey, keybytes, Callback_get_keys_buffer, &cxt);
     if (status != PMEMKV_STATUS_OK) PmemkvJavaException(env).ThrowException(status);
 }
@@ -134,7 +134,7 @@ extern "C" JNIEXPORT void JNICALL Java_io_pmem_pmemkv_Database_database_1get_1ke
         (JNIEnv* env, jobject obj, jlong pointer, jint keybytes, jobject key, jobject callback) {
     auto engine = (pmemkv_db*) pointer;
     const char* ckey = (char*) env->GetDirectBufferAddress(key);
-    auto cxt = Context(env, callback,  METHOD_GET_KEYS_BUFFER);
+    auto cxt = Context(env, callback, METHOD_GET_KEYS_BUFFER);
     auto status = pmemkv_get_below(engine, ckey, keybytes, Callback_get_keys_buffer, &cxt);
     if (status != PMEMKV_STATUS_OK) PmemkvJavaException(env).ThrowException(status);
 }
@@ -144,7 +144,7 @@ extern "C" JNIEXPORT void JNICALL Java_io_pmem_pmemkv_Database_database_1get_1ke
     auto engine = (pmemkv_db*) pointer;
     const char* ckey1 = (char*) env->GetDirectBufferAddress(key1);
     const char* ckey2 = (char*) env->GetDirectBufferAddress(key2);
-    auto cxt = Context(env, callback,  METHOD_GET_KEYS_BUFFER);
+    auto cxt = Context(env, callback, METHOD_GET_KEYS_BUFFER);
     auto status = pmemkv_get_between(engine, ckey1, keybytes1, ckey2, keybytes2, Callback_get_keys_buffer, &cxt);
     if (status != PMEMKV_STATUS_OK) PmemkvJavaException(env).ThrowException(status);
 }
@@ -153,7 +153,8 @@ extern "C" JNIEXPORT jlong JNICALL Java_io_pmem_pmemkv_Database_database_1count_
         (JNIEnv* env, jobject obj, jlong pointer) {
     auto engine = (pmemkv_db*) pointer;
     size_t count;
-    pmemkv_count_all(engine, &count);
+    auto status = pmemkv_count_all(engine, &count);
+    if (status != PMEMKV_STATUS_OK) PmemkvJavaException(env).ThrowException(status);
 
     return count;
 }
@@ -164,7 +165,8 @@ extern "C" JNIEXPORT jlong JNICALL Java_io_pmem_pmemkv_Database_database_1count_
     const char* ckey = (char*) env->GetDirectBufferAddress(key);
 
     size_t count;
-    pmemkv_count_above(engine, ckey, keybytes, &count);
+    auto status = pmemkv_count_above(engine, ckey, keybytes, &count);
+    if (status != PMEMKV_STATUS_OK) PmemkvJavaException(env).ThrowException(status);
 
     return count;
 }
@@ -175,7 +177,8 @@ extern "C" JNIEXPORT jlong JNICALL Java_io_pmem_pmemkv_Database_database_1count_
     const char* ckey = (char*) env->GetDirectBufferAddress(key);
 
     size_t count;
-    pmemkv_count_below(engine, ckey, keybytes, &count);
+    auto status = pmemkv_count_below(engine, ckey, keybytes, &count);
+    if (status != PMEMKV_STATUS_OK) PmemkvJavaException(env).ThrowException(status);
 
     return count;
 }
@@ -187,7 +190,8 @@ extern "C" JNIEXPORT jlong JNICALL Java_io_pmem_pmemkv_Database_database_1count_
     const char* ckey2 = (char*) env->GetDirectBufferAddress(key2);
 
     size_t count;
-    pmemkv_count_between(engine, ckey1, keybytes1, ckey2, keybytes2, &count);
+    auto status = pmemkv_count_between(engine, ckey1, keybytes1, ckey2, keybytes2, &count);
+    if (status != PMEMKV_STATUS_OK) PmemkvJavaException(env).ThrowException(status);
 
     return count;
 }
@@ -197,7 +201,7 @@ int Callback_get_all_buffer(const char* k, size_t kb, const char* v, size_t vb, 
 
     jobject keybuf = c->env->NewDirectByteBuffer( const_cast<char*>(k), kb);
     jobject valuebuf = c->env->NewDirectByteBuffer(const_cast<char*>(v), vb);
-    if( keybuf && valuebuf) {
+    if(keybuf && valuebuf) {
         c->env->CallVoidMethod(c->callback, c->mid, kb, keybuf, vb, valuebuf);
         c->env->DeleteLocalRef(keybuf);
         c->env->DeleteLocalRef(valuebuf);
@@ -252,7 +256,6 @@ extern "C" JNIEXPORT jboolean JNICALL Java_io_pmem_pmemkv_Database_database_1exi
     if (status != PMEMKV_STATUS_OK && status != PMEMKV_STATUS_NOT_FOUND)
         PmemkvJavaException(env).ThrowException(status);
     return status == PMEMKV_STATUS_OK;
-
 }
 
 struct ContextGetByteArray {

--- a/pmemkv-binding/src/main/java/io/pmem/pmemkv/Database.java
+++ b/pmemkv-binding/src/main/java/io/pmem/pmemkv/Database.java
@@ -18,7 +18,8 @@ import java.nio.ByteBuffer;
  * In most cases user needs to implement Converter interface, which provides
  * functionality of converting between key and value types, and ByteBuffer.
  *
- * @see <a href= "https://github.com/pmem/pmemkv/">Pmemkv</a>
+ * @see <a href= "https://github.com/pmem/pmemkv/">Pmemkv</a> library
+ *      description.
  *
  * @param <K>
  *            the type of key stored in the pmemkv datastore
@@ -251,6 +252,7 @@ public class Database<K, V> {
 	 * @param callback
 	 *            Function to be called for each specified key/value pair.
 	 * @throws DatabaseException
+	 * @since 1.0
 	 */
 	public void getAbove(K key, KeyValueCallback<K, V> callback) throws DatabaseException {
 		ByteBuffer direct_key = getDirectBuffer(keyConverter.toByteBuffer(key));
@@ -277,6 +279,7 @@ public class Database<K, V> {
 	 * @param callback
 	 *            Function to be called for each specified key/value pair.
 	 * @throws DatabaseException
+	 * @since 1.0
 	 */
 	public void getBelow(K key, KeyValueCallback<K, V> callback) throws DatabaseException {
 		ByteBuffer direct_key = getDirectBuffer(keyConverter.toByteBuffer(key));
@@ -304,6 +307,7 @@ public class Database<K, V> {
 	 * @param callback
 	 *            Function to be called for each specified key/value pair.
 	 * @throws DatabaseException
+	 * @since 1.0
 	 */
 	public void getBetween(K key1, K key2, KeyValueCallback<K, V> callback) throws DatabaseException {
 		ByteBuffer direct_key1 = getDirectBuffer(keyConverter.toByteBuffer(key1));
@@ -325,6 +329,7 @@ public class Database<K, V> {
 	 *            key to query for.
 	 * @return true if key exists in the datastore, false otherwise
 	 * @throws DatabaseException
+	 * @since 1.0
 	 */
 	public boolean exists(K key) throws DatabaseException {
 		ByteBuffer direct_key = getDirectBuffer(keyConverter.toByteBuffer(key));
@@ -339,6 +344,7 @@ public class Database<K, V> {
 	 * @param callback
 	 *            Function to be called for each specified key/value pair.
 	 * @throws DatabaseException
+	 * @since 1.0
 	 */
 	public void get(K key, ValueCallback<V> callback) throws DatabaseException {
 		ByteBuffer direct_key = getDirectBuffer(keyConverter.toByteBuffer(key));
@@ -356,6 +362,7 @@ public class Database<K, V> {
 	 *            key to query for.
 	 * @return Copy of value associated with the given key or null if not found.
 	 * @throws DatabaseException
+	 * @since 1.0
 	 */
 	public V getCopy(K key) throws DatabaseException {
 		byte value[];
@@ -378,6 +385,7 @@ public class Database<K, V> {
 	 * @param value
 	 *            data to be inserted for the specified key.
 	 * @throws DatabaseException
+	 * @since 1.0
 	 */
 	public void put(K key, V value) throws DatabaseException {
 		ByteBuffer direct_key = getDirectBuffer(keyConverter.toByteBuffer(key));
@@ -394,6 +402,7 @@ public class Database<K, V> {
 	 * @return true if element was removed, false if element didn't exist before
 	 *         removal.
 	 * @throws DatabaseException
+	 * @since 1.0
 	 */
 	public boolean remove(K key) throws DatabaseException {
 		ByteBuffer direct_key = getDirectBuffer(keyConverter.toByteBuffer(key));
@@ -439,8 +448,10 @@ public class Database<K, V> {
 		 * @param size
 		 *            size of the pmemkv datastore.
 		 * @return this builder object.
+		 * @throws BuilderException
+		 * @since 1.0
 		 */
-		public Builder<K, V> setSize(long size) {
+		public Builder<K, V> setSize(long size) throws BuilderException {
 			config_put_int(config, "size", size);
 			return this;
 		}
@@ -451,8 +462,10 @@ public class Database<K, V> {
 		 * @param forceCreate
 		 *            specify force_create engine's parameter.
 		 * @return this builder object.
+		 * @throws BuilderException
+		 * @since 1.0
 		 */
-		public Builder<K, V> setForceCreate(boolean forceCreate) {
+		public Builder<K, V> setForceCreate(boolean forceCreate) throws BuilderException {
 			config_put_int(config, "force_create", forceCreate ? 1 : 0);
 			return this;
 		}
@@ -462,9 +475,11 @@ public class Database<K, V> {
 		 *
 		 * @param path
 		 *            specify path engine's parameter.
-		 * @return this builder.
+		 * @return this builder object.
+		 * @throws BuilderException
+		 * @since 1.0
 		 */
-		public Builder<K, V> setPath(String path) {
+		public Builder<K, V> setPath(String path) throws BuilderException {
 			config_put_string(config, "path", path);
 			return this;
 		}
@@ -474,6 +489,7 @@ public class Database<K, V> {
 		 * within this builder.
 		 *
 		 * @return instance of pmemkv Database.
+		 * @since 1.0
 		 */
 		public Database<K, V> build() {
 			/* Engine takes config's ownership */
@@ -490,7 +506,8 @@ public class Database<K, V> {
 		 *
 		 * @param newKeyConverter
 		 *            Converter object from K type to ByteBuffer.
-		 * @return this builder.
+		 * @return this builder object.
+		 * @since 1.0
 		 */
 		public Builder<K, V> setKeyConverter(Converter<K> newKeyConverter) {
 			this.keyConverter = newKeyConverter;
@@ -508,7 +525,8 @@ public class Database<K, V> {
 		 * @param newValueConverter
 		 *            Converter object from V type to ByteBuffer.
 		 *
-		 * @return this builder.
+		 * @return this builder object.
+		 * @since 1.0
 		 */
 		public Builder<K, V> setValueConverter(Converter<V> newValueConverter) {
 			this.valueConverter = newValueConverter;

--- a/pmemkv-binding/src/main/java/io/pmem/pmemkv/Database.java
+++ b/pmemkv-binding/src/main/java/io/pmem/pmemkv/Database.java
@@ -153,9 +153,10 @@ public class Database<K, V> {
 	 * Returns number of key/value pairs currently stored in the pmemkv datastore.
 	 *
 	 * @return Total number of elements in the datastore.
+	 * @throws DatabaseException
 	 * @since 1.0
 	 */
-	public long countAll() {
+	public long countAll() throws DatabaseException {
 		return database_count_all(pointer);
 	}
 
@@ -170,9 +171,10 @@ public class Database<K, V> {
 	 *            Sets the lower bound for querying.
 	 * @return Number of key/value pairs in the datastore, whose keys are greater
 	 *         than the given key.
+	 * @throws DatabaseException
 	 * @since 1.0
 	 */
-	public long countAbove(K key) {
+	public long countAbove(K key) throws DatabaseException {
 		ByteBuffer direct_key = getDirectBuffer(keyConverter.toByteBuffer(key));
 		return database_count_above_buffer(pointer, direct_key.position(), direct_key);
 	}
@@ -188,9 +190,10 @@ public class Database<K, V> {
 	 *            Sets the upper bound for querying.
 	 * @return Number of key/value pairs in the datastore, whose keys are less than
 	 *         the given key.
+	 * @throws DatabaseException
 	 * @since 1.0
 	 */
-	public long countBelow(K key) {
+	public long countBelow(K key) throws DatabaseException {
 		ByteBuffer direct_key = getDirectBuffer(keyConverter.toByteBuffer(key));
 		return database_count_below_buffer(pointer, direct_key.position(), direct_key);
 	}
@@ -207,9 +210,10 @@ public class Database<K, V> {
 	 * @param key2
 	 *            Sets the upper bound for querying.
 	 * @return Number of key/value pairs in the datastore, between given keys.
+	 * @throws DatabaseException
 	 * @since 1.0
 	 */
-	public long countBetween(K key1, K key2) {
+	public long countBetween(K key1, K key2) throws DatabaseException {
 		ByteBuffer direct_key1 = getDirectBuffer(keyConverter.toByteBuffer(key1));
 		ByteBuffer direct_key2 = getDirectBuffer(keyConverter.toByteBuffer(key2));
 		return database_count_between_buffer(pointer, direct_key1.position(), direct_key1, direct_key2.position(),

--- a/pmemkv-binding/src/test/java/io/pmem/pmemkv/CmapTest.java
+++ b/pmemkv-binding/src/test/java/io/pmem/pmemkv/CmapTest.java
@@ -78,9 +78,40 @@ public class CmapTest {
 			db = openDB(ENGINE, file);
 			Assert.fail();
 		} catch (DatabaseException e) {
-
+			/* file doesn't exist, open should throw */
 		}
 
 		assertNull(db);
+	}
+
+	@Test
+	public void throwsExceptionOnSortedCountFuncs() {
+		String file = folder.getRoot() + File.pathSeparator + "testfile";
+		Database<ByteBuffer, ByteBuffer> db = createDB(ENGINE, file);
+		ByteBuffer key1 = stringToByteBuffer("key1");
+		ByteBuffer key2 = stringToByteBuffer("key2");
+
+		try {
+			db.countAbove(key1);
+			Assert.fail();
+		} catch (DatabaseException e) {
+			/* countAbove for unsorted engines should throw NotSupported */
+		}
+
+		try {
+			db.countBelow(key1);
+			Assert.fail();
+		} catch (DatabaseException e) {
+			/* countBelow for unsorted engines should throw NotSupported */
+		}
+
+		try {
+			db.countBetween(key1, key2);
+			Assert.fail();
+		} catch (DatabaseException e) {
+			/* countBetween for unsorted engines should throw NotSupported */
+		}
+
+		db.stop();
 	}
 }


### PR DESCRIPTION
Right now the only method not throwing is `pmemkv_config_delete`... can we/should we handle this as well, somehow...?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmemkv-java/138)
<!-- Reviewable:end -->
