### PR TITLE
[jni] change ExceptionOccured to ExceptionCheck and exception clear

### DIFF
--- a/jni-binding/io_pmem_pmemkv_Database.cpp
+++ b/jni-binding/io_pmem_pmemkv_Database.cpp
@@ -124,7 +124,8 @@ void Callback_get_value_buffer(const char* v, size_t vb, void *arg) {
 int Callback_get_keys_buffer(const char* k, size_t kb, const char* v, size_t vb, void *arg) {
     const auto c = static_cast<Context*>(arg);
     Callback_get_value_buffer(k, kb, arg);
-    if (c->env->ExceptionOccurred()) {
+    if (c->env->ExceptionCheck() = JNI_TRUE) {
+        c->env->ExceptionClear();
         return 1;
     }
     return 0;
@@ -226,7 +227,8 @@ int Callback_get_all_buffer(const char* k, size_t kb, const char* v, size_t vb, 
         c->env->DeleteLocalRef(keybuf);
         c->env->DeleteLocalRef(valuebuf);
     }
-    if( c->env->ExceptionOccurred()) {
+    if (c->env->ExceptionCheck() == JNI_TRUE) {
+        c->env->ExceptionClear();
         return 1;
     }
     return 0;


### PR DESCRIPTION
ExceptionOccured returns the exception that is currently in the process
of being thrown and don't clear it. ExceptionCheck returns just boolean
and then should be invoke ExceptionClean when appropriate.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmemkv-java/156)
<!-- Reviewable:end -->
