### PR TITLE
[Fix] Align exception checking to JNI guidelines

### DIFF
--- a/jni-binding/io_pmem_pmemkv_Database.cpp
+++ b/jni-binding/io_pmem_pmemkv_Database.cpp
@@ -29,22 +29,24 @@ public:
     void ThrowException(pmem::kv::status status, const char* msg =  pmemkv_errormsg()){
         jclass exception_class;
         exception_class = env->FindClass(PmemkvStatusDispatcher[status]);
-        if(exception_class == NULL) {
+        if (exception_class == NULL) {
             exception_class = env->FindClass(DatabaseException);
         }
-        if(exception_class == NULL) {
+        if (exception_class == NULL) {
             exception_class = env->FindClass(GeneralException);
         }
         env->ThrowNew(exception_class, msg);
+        env->DeleteLocalRef(exception_class);
     }
 
     void ThrowException(const char* signature, const char* msg=""){
         jclass exception_class;
         exception_class = env->FindClass(signature);
-        if(exception_class == NULL) {
+        if (exception_class == NULL) {
             exception_class = env->FindClass(GeneralException);
         }
         env->ThrowNew(exception_class, msg);
+        env->DeleteLocalRef(exception_class);
     }
 };
 
@@ -86,7 +88,7 @@ extern "C" JNIEXPORT jlong JNICALL Java_io_pmem_pmemkv_Database_database_1start
     env->ReleaseStringUTFChars(engine, cengine);
 
     if (status != pmem::kv::status::OK) {
-            PmemkvJavaException(env).ThrowException(status);
+        PmemkvJavaException(env).ThrowException(status);
     }
     return (jlong) db;
 }
@@ -115,7 +117,6 @@ void Callback_get_value_buffer(const char* v, size_t vb, void *arg) {
     const auto c = static_cast<Context*>(arg);
     // OutOfMemoryError may occurr
     if (jobject valuebuf = c->env->NewDirectByteBuffer(const_cast<char*>(v), vb)) {
-        // Rerise exception
         c->env->CallStaticVoidMethod(c->env->GetObjectClass(c->db), c->mid, c->db, c->callback, vb, valuebuf);
         c->env->DeleteLocalRef(valuebuf);
     }
@@ -124,7 +125,7 @@ void Callback_get_value_buffer(const char* v, size_t vb, void *arg) {
 int Callback_get_keys_buffer(const char* k, size_t kb, const char* v, size_t vb, void *arg) {
     const auto c = static_cast<Context*>(arg);
     Callback_get_value_buffer(k, kb, arg);
-    if (c->env->ExceptionOccurred()) {
+    if (c->env->ExceptionCheck() == JNI_TRUE) {
         return 1;
     }
     return 0;
@@ -135,6 +136,7 @@ extern "C" JNIEXPORT void JNICALL Java_io_pmem_pmemkv_Database_database_1get_1ke
     auto engine = reinterpret_cast<pmem::kv::db*>(pointer);
     auto ctx = Context(env, obj, callback, keyCallbackID);
     auto status = engine->get_all(Callback_get_keys_buffer, &ctx);
+    if (env->ExceptionCheck() == JNI_TRUE) return;
     if (status != pmem::kv::status::OK) PmemkvJavaException(env).ThrowException(status);
 }
 
@@ -145,6 +147,7 @@ extern "C" JNIEXPORT void JNICALL Java_io_pmem_pmemkv_Database_database_1get_1ke
     pmem::kv::string_view cppkey(ckey, keybytes);
     auto cxt = Context(env, obj, callback, keyCallbackID);
     auto status = engine->get_above(cppkey, Callback_get_keys_buffer, &cxt);
+    if (env->ExceptionCheck() == JNI_TRUE) return;
     if (status != pmem::kv::status::OK) PmemkvJavaException(env).ThrowException(status);
 }
 
@@ -155,6 +158,7 @@ extern "C" JNIEXPORT void JNICALL Java_io_pmem_pmemkv_Database_database_1get_1ke
     pmem::kv::string_view cppkey(ckey, keybytes);
     auto cxt = Context(env, obj, callback, keyCallbackID);
     auto status = engine->get_below(cppkey, Callback_get_keys_buffer, &cxt);
+    if (env->ExceptionCheck() == JNI_TRUE) return;
     if (status != pmem::kv::status::OK) PmemkvJavaException(env).ThrowException(status);
 }
 
@@ -167,6 +171,7 @@ extern "C" JNIEXPORT void JNICALL Java_io_pmem_pmemkv_Database_database_1get_1ke
     pmem::kv::string_view cppkey2(ckey2, keybytes2);
     auto cxt = Context(env, obj, callback, keyCallbackID);
     auto status = engine->get_between(cppkey1, cppkey2, Callback_get_keys_buffer, &cxt);
+    if (env->ExceptionCheck() == JNI_TRUE) return;
     if (status != pmem::kv::status::OK) PmemkvJavaException(env).ThrowException(status);
 }
 
@@ -220,13 +225,18 @@ int Callback_get_all_buffer(const char* k, size_t kb, const char* v, size_t vb, 
     const auto c = static_cast<Context*>(arg);
 
     jobject keybuf = c->env->NewDirectByteBuffer(const_cast<char*>(k), kb);
+    if (c->env->ExceptionCheck() == JNI_TRUE)
+        return 1;
     jobject valuebuf = c->env->NewDirectByteBuffer(const_cast<char*>(v), vb);
+    if (c->env->ExceptionCheck() == JNI_TRUE)
+        return 1;
+
     if(keybuf && valuebuf) {
         c->env->CallStaticVoidMethod(c->env->GetObjectClass(c->db), c->mid, c->db, c->callback, kb, keybuf, vb, valuebuf);
         c->env->DeleteLocalRef(keybuf);
         c->env->DeleteLocalRef(valuebuf);
     }
-    if( c->env->ExceptionOccurred()) {
+    if (c->env->ExceptionCheck() == JNI_TRUE) {
         return 1;
     }
     return 0;
@@ -237,6 +247,8 @@ extern "C" JNIEXPORT void JNICALL Java_io_pmem_pmemkv_Database_database_1get_1al
     auto engine = reinterpret_cast<pmem::kv::db*>(pointer);
     auto cxt = Context(env, obj, callback, keyValueCallbackID);
     auto status = engine->get_all(Callback_get_all_buffer, &cxt);
+    if (env->ExceptionCheck() == JNI_TRUE)
+        return; // Propagate exception
     if (status != pmem::kv::status::OK) PmemkvJavaException(env).ThrowException(status);
 }
 
@@ -247,6 +259,8 @@ extern "C" JNIEXPORT void JNICALL Java_io_pmem_pmemkv_Database_database_1get_1ab
     pmem::kv::string_view cppkey(ckey, keybytes);
     auto cxt = Context(env, obj, callback, keyValueCallbackID);
     auto status = engine->get_above(cppkey, Callback_get_all_buffer, &cxt);
+    if (env->ExceptionCheck() == JNI_TRUE)
+        return; // Propagate exception
     if (status != pmem::kv::status::OK) PmemkvJavaException(env).ThrowException(status);
 }
 
@@ -257,6 +271,8 @@ extern "C" JNIEXPORT void JNICALL Java_io_pmem_pmemkv_Database_database_1get_1be
     pmem::kv::string_view cppkey(ckey, keybytes);
     auto cxt = Context(env, obj, callback, keyValueCallbackID);
     auto status = engine->get_below(cppkey, Callback_get_all_buffer,&cxt);
+    if (env->ExceptionCheck() == JNI_TRUE)
+        return; // Propagate exception
     if (status != pmem::kv::status::OK) PmemkvJavaException(env).ThrowException(status);
 }
 
@@ -269,6 +285,8 @@ extern "C" JNIEXPORT void JNICALL Java_io_pmem_pmemkv_Database_database_1get_1be
     pmem::kv::string_view cppkey2(ckey2, keybytes2);
     auto cxt = Context(env, obj, callback, keyValueCallbackID);
     auto status = engine->get_between(cppkey1, cppkey2, Callback_get_all_buffer, &cxt);
+    if (env->ExceptionCheck() == JNI_TRUE)
+        return; // Propagate exception
     if (status != pmem::kv::status::OK) PmemkvJavaException(env).ThrowException(status);
 }
 
@@ -310,6 +328,7 @@ extern "C" JNIEXPORT void JNICALL Java_io_pmem_pmemkv_Database_database_1get_1bu
     pmem::kv::string_view cppkey(ckey, keybytes);
     auto cxt = Context(env, obj, callback, valueCallbackID);
     auto status = engine->get(cppkey, Callback_get_value_buffer, &cxt);
+    if (env->ExceptionCheck() == JNI_TRUE) return; // Propagate exception
     if (status != pmem::kv::status::OK) PmemkvJavaException(env).ThrowException(status);
 }
 
@@ -320,6 +339,7 @@ extern "C" JNIEXPORT jbyteArray JNICALL Java_io_pmem_pmemkv_Database_database_1g
     pmem::kv::string_view cppkey(ckey, keybytes);
     ContextGetByteArray cxt = ContextGetByteArray(env);
     auto status = engine->get(cppkey, callback_get_byte_array, &cxt);
+    if (env->ExceptionCheck() == JNI_TRUE) return nullptr; // Propagate exception
     if (status != pmem::kv::status::OK)
         PmemkvJavaException(env).ThrowException(status);
     return cxt.result;

--- a/pmemkv-binding/src/test/java/io/pmem/pmemkv/ExceptionTest.java
+++ b/pmemkv-binding/src/test/java/io/pmem/pmemkv/ExceptionTest.java
@@ -68,165 +68,116 @@ public class ExceptionTest {
 
 	@Test
 	public void throwsExceptionOnStartWhenPathIsMissing() {
-		Database<ByteBuffer, ByteBuffer> db = null;
-		boolean exception_occured = false;
-		try {
-			db = new Database.Builder<ByteBuffer, ByteBuffer>(ENGINE)
+		Exception exception = assertThrows(InvalidArgumentException.class, () -> {
+			Database<ByteBuffer, ByteBuffer> db = new Database.Builder<ByteBuffer, ByteBuffer>(ENGINE)
 					.setSize(DEFAULT_DB_SIZE)
 					.build();
-			Assert.fail();
-		} catch (InvalidArgumentException kve) {
-			exception_occured = true;
-		} catch (Exception e) {
-			Assert.fail();
-		}
-		assertTrue(exception_occured);
-		assertNull(db);
+		});
+		assertTrue(exception.getMessage().length() > 0);
 	}
 
 	@Test
 	public void throwsExceptionOnStartWhenSizeIsMissing() {
-		Database<ByteBuffer, ByteBuffer> db = null;
-		boolean exception_occured = false;
-		try {
-			db = new Database.Builder<ByteBuffer, ByteBuffer>(ENGINE)
+		Exception exception = assertThrows(InvalidArgumentException.class, () -> {
+			Database<ByteBuffer, ByteBuffer> db = new Database.Builder<ByteBuffer, ByteBuffer>(ENGINE)
 					.setPath(DB_DIR)
 					.build();
-			Assert.fail();
-		} catch (InvalidArgumentException kve) {
-			exception_occured = true;
-		} catch (Exception e) {
-			Assert.fail();
-		}
-		assertNull(db);
-		assertTrue(exception_occured);
+		});
+		assertTrue(exception.getMessage().length() > 0);
 	}
 
 	@Test
 	public void throwsExceptionOnStartWhenEngineIsInvalidTest() {
-		Database<ByteBuffer, ByteBuffer> db = null;
-		boolean exception_occured = false;
-		try {
-			db = buildDB("nope.nope");
-			Assert.fail();
-		} catch (WrongEngineNameException kve) {
-			exception_occured = true;
-		} catch (Exception e) {
-			Assert.fail();
-		}
-		assertNull(db);
-		assertTrue(exception_occured);
+		Exception exception = assertThrows(WrongEngineNameException.class, () -> {
+			Database<ByteBuffer, ByteBuffer> db = buildDB("nope.nope");
+		});
+		assertTrue(exception.getMessage().length() > 0);
 	}
 
 	@Test
 	public void throwsExceptionOnStartWhenPathIsInvalidTest() {
-		Database<ByteBuffer, ByteBuffer> db = null;
-		boolean exception_occured = false;
-		try {
-			db = new Database.Builder<ByteBuffer, ByteBuffer>(ENGINE)
+		Exception exception = assertThrows(DatabaseException.class, () -> {
+			Database<ByteBuffer, ByteBuffer> db = new Database.Builder<ByteBuffer, ByteBuffer>(ENGINE)
 					.setSize(DEFAULT_DB_SIZE)
 					.setPath("/tmp/123/234/345/456/567/678/nope.nope")
 					.build();
-			Assert.fail();
 			/*
 			 * It should be InvalidArgumentException, but:
 			 * https://github.com/pmem/pmemkv/issues/565
 			 */
-		} catch (DatabaseException kve) {
-			exception_occured = true;
-		} catch (Exception e) {
-			Assert.fail();
-		}
-		assertNull(db);
-		assertTrue(exception_occured);
+		});
+		assertTrue(exception.getMessage().length() > 0);
 	}
 
 	@Test
 	public void throwsExceptionOnStartWhenPathIsWrongTypeTest() {
-		Database<ByteBuffer, ByteBuffer> db = null;
-		boolean exception_occured = false;
-		try {
-			db = new Database.Builder<ByteBuffer, ByteBuffer>(ENGINE)
+		Exception exception = assertThrows(DatabaseException.class, () -> {
+			Database<ByteBuffer, ByteBuffer> db = new Database.Builder<ByteBuffer, ByteBuffer>(ENGINE)
 					.setSize(DEFAULT_DB_SIZE)
 					.setPath("1234")
 					.build();
-			Assert.fail();
 			/*
 			 * It's not a valid path, so it should be InvalidArgumentException, but:
 			 * https://github.com/pmem/pmemkv/issues/565
 			 */
-		} catch (DatabaseException kve) {
-			exception_occured = true;
-		} catch (Exception e) {
-			Assert.fail();
-		}
-		assertNull(db);
-		assertTrue(exception_occured);
+		});
+		assertTrue(exception.getMessage().length() > 0);
 	}
 
 	/* Exceptions in Gets methods */
 
 	@Test
-	public void exceptionInGetallTest() {
-		int exception_counter = 0;
-		try {
+	public void exceptionInGetAllTest() {
+		String exception_message = "Inner exception";
+		Exception exception = assertThrows(CustomException.class, () -> {
 			db.getAll((k, v) -> {
-				throw new RuntimeException("Inner exception");
+				throw new CustomException(exception_message);
 			});
-		} catch (Exception e) {
-			exception_counter++;
-		}
-		assertEquals(exception_counter, 1);
+		});
+		assertEquals(exception_message, exception.getMessage());
 	}
 
 	@Test
 	public void exceptionInGetKeysTest() {
-		int exception_counter = 0;
+		String exception_message = "Inner exception";
 		AtomicInteger loop_counter = new AtomicInteger(0);
-		try {
+		Exception exception = assertThrows(CustomException.class, () -> {
 			db.getKeys((k) -> {
 				loop_counter.getAndIncrement();
-				throw new RuntimeException("Inner exception");
+				throw new CustomException(exception_message);
 			});
-		} catch (Exception e) {
-			exception_counter++;
-		}
-		assertEquals(exception_counter, 1);
+		});
+		assertEquals(exception_message, exception.getMessage());
 		assertEquals(loop_counter.intValue(), 1);
 	}
 
 	@Test
 	public void exceptionInTheMiddleOfGetKeysTest() {
-		int exception_counter = 0;
+		String exception_message = "Inner exception";
 		AtomicInteger loop_counter = new AtomicInteger(0);
-		try {
+		Exception exception = assertThrows(CustomException.class, () -> {
 			db.getKeys((k) -> {
 				loop_counter.getAndIncrement();
 				if (k.getInt() == 15) {
-					throw new RuntimeException("Inner exception");
+					throw new CustomException(exception_message);
 				}
 			});
-		} catch (Exception e) {
-			exception_counter++;
-		}
-		assertEquals(exception_counter, 1);
+		});
+		assertEquals(exception_message, exception.getMessage());
 		assertEquals(loop_counter.intValue(), 16);
 	}
 
 	@Test
 	public void exceptionInGet() {
 		ByteBuffer key = ByteBuffer.allocateDirect(256);
+		String exception_message = "Lorem ipsum";
 		key.putInt(1);
-		boolean exception_occured = false;
-		try {
+		Exception exception = assertThrows(CustomException.class, () -> {
 			db.get(key, (ByteBuffer k) -> {
-				throw new CustomException("Lorem ipsum");
+				throw new CustomException(exception_message);
 			});
-		} catch (CustomException e) {
-			exception_occured = true;
-			assertEquals(e.getMessage(), "Lorem ipsum");
-		}
-		assertTrue(exception_occured);
+		});
+		assertEquals(exception.getMessage(), exception_message);
 	}
 
 	/* Other exceptions */


### PR DESCRIPTION
### PR description:
This PR fixes #159 and also introduce proper handling of exceptions as an example.
Changes was tested by adding `env->ThrowNew(class(java.lang.OutOfMemoryError), msg);` to simulate error in `env->NewDirectByteBuffer` and tests crashed as expected.
Bonus:
There is need to check when and why the `ExceptionCheck() == JNI_TRUE` is a true.

### Commit description:
This commit introduces proper handling of exceptions
and add test as example how to handle exception with specified class.
Fixes #159

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmemkv-java/163)
<!-- Reviewable:end -->
