### PR TITLE
utils: bump dependencies and cleanup

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        CONFIG: ["TYPE=maven OS=ubuntu OS_VER=20.04_clean PUSH_IMAGE=1"]
+        CONFIG: ["TYPE=maven OS=ubuntu OS_VER=21.04_clean PUSH_IMAGE=1"]
     steps:
       - name: Clone the git repo
         uses: actions/checkout@v2

--- a/utils/docker/images/Dockerfile.ubuntu-21.04_clean
+++ b/utils/docker/images/Dockerfile.ubuntu-21.04_clean
@@ -8,12 +8,12 @@
 #
 
 # Pull base image
-FROM registry.hub.docker.com/library/ubuntu:20.04
+FROM registry.hub.docker.com/library/ubuntu:21.04
 MAINTAINER igor.chorazewicz@intel.com
 
 # Set required environment variables
 ENV OS ubuntu
-ENV OS_VER 20.04_clean
+ENV OS_VER 21.04_clean
 ENV PACKAGE_MANAGER deb
 ENV NOTTY 1
 ENV JAVA_HOME /usr/lib/jvm/java-8-openjdk-amd64

--- a/utils/docker/images/install-dependencies.sh
+++ b/utils/docker/images/install-dependencies.sh
@@ -31,8 +31,8 @@ echo "Extra mvn params (taken from env): ${MVN_PARAMS}"
 PREFIX=/usr
 # common: release 1.4, 15.02.2021
 PMEMKV_VERSION="ecb8fd65c5b07ed002d1018418ef809ab50d4e18"
-# common: release 1.0.1, 11.03.2021
-JAVA_VERSION="827f911c977d475511ca9b29cdec3c12425a3936"
+# common: release 1.2.0, 02.07.2021
+JAVA_VERSION="9a32f9f518198ae575242b448f61514c231b5a60"
 
 echo "Build and install PMEMKV (JNI needs it)"
 git clone https://github.com/pmem/pmemkv.git
@@ -49,7 +49,8 @@ cmake .. -DCMAKE_BUILD_TYPE=RelWithDebInfo \
 	-DENGINE_VSMAP=OFF \
 	-DBUILD_DOC=OFF \
 	-DBUILD_EXAMPLES=OFF \
-	-DBUILD_TESTS=OFF
+	-DBUILD_TESTS=OFF \
+	-DTESTS_USE_VALGRIND=OFF
 make -j$(nproc)
 make -j$(nproc) install
 
@@ -75,7 +76,7 @@ rm -r ${deps_dir}
 
 echo "Uninstall pmemkv"
 cd ${WORKDIR}/pmemkv/build
-make uninstall
+make -j$(nproc) uninstall
 
 echo "Remove installed binding files (from local mvn repository)"
 rm -r /opt/java/repository/io/pmem/*

--- a/utils/docker/images/install-libpmemobj-cpp.sh
+++ b/utils/docker/images/install-libpmemobj-cpp.sh
@@ -18,9 +18,8 @@ PREFIX=/usr
 PACKAGE_TYPE=${1^^} #To uppercase
 echo "PACKAGE_TYPE: ${PACKAGE_TYPE}"
 
-# Merge pull request #1048 from lukaszstolarczuk/tests-gdb; 04.03.2021
-# It contains new exception: pool_invalid_argument
-LIBPMEMOBJ_CPP_VERSION="7cc2f387fa261f370a3c5f0f9e122756bc2fffb0"
+# master: Merge pull request #1126 from igchor/test_workaround; 05.07.2021
+LIBPMEMOBJ_CPP_VERSION="2543afae7b1e9e82809a3e4280753b33cdab8136"
 
 build_dir=$(mktemp -d -t libpmemobj-cpp-XXX)
 
@@ -34,7 +33,7 @@ cd build
 
 # turn off all redundant components
 cmake .. -DCPACK_GENERATOR="${PACKAGE_TYPE}" -DCMAKE_INSTALL_PREFIX=${PREFIX} \
-	-DBUILD_EXAMPLES=OFF -DBUILD_TESTS=OFF -DBUILD_DOC=OFF -DBUILD_BENCHMARKS=OFF
+	-DBUILD_EXAMPLES=OFF -DBUILD_TESTS=OFF -DTESTS_USE_VALGRIND=OFF -DBUILD_DOC=OFF -DBUILD_BENCHMARKS=OFF
 
 if [ "${PACKAGE_TYPE}" = "" ]; then
 	make -j$(nproc) install

--- a/utils/docker/images/install-pmdk.sh
+++ b/utils/docker/images/install-pmdk.sh
@@ -17,9 +17,8 @@ PACKAGE_TYPE=$1
 PREFIX=${2:-/usr}
 echo "PACKAGE_TYPE: ${PACKAGE_TYPE}"
 
-# master: Merge pull request #5150 from kilobyte/rpm-no-lto, 16.02.2021
-# contains fix for packaging
-PMDK_VERSION="7f88d9fae088b81936d2f6d5235169e90e7478c7"
+# master: 1.11.0, 02.07.2021
+PMDK_VERSION="8583fcfd68764ac6779e6f93db89b06971b26704"
 
 git clone https://github.com/pmem/pmdk --shallow-since=2020-12-01
 cd pmdk

--- a/utils/docker/images/prepare-pmemkv.sh
+++ b/utils/docker/images/prepare-pmemkv.sh
@@ -21,8 +21,8 @@ if [ -z "${PACKAGE_TYPE}" ]; then
 	exit 1
 fi
 
-# master: Merge pull request #952 from karczex/dram_cmap_engine; 05.03.2021
-current_pmemkv_version="e135a8c757a8deb9a58d826954780d9eaf1ec5ab"
+# master: Merge pull request #991 from lukaszstolarczuk/update-dockers; 05.07.2021
+current_pmemkv_version="fd0f0f20989b1d8c75f54f3151542475a7da37d0"
 
 # stable-1.0: 1.0.3 release; 06.10.2020
 stable_1_pmemkv_version="77ae3ef23dc2b2db9c012dc343b125a785a0ffbc"
@@ -48,7 +48,7 @@ prepare_pmemkv () {
 	cd build
 	# turn off all redundant components
 	cmake .. -DCPACK_GENERATOR="${PACKAGE_TYPE}" -DCMAKE_INSTALL_PREFIX=${PREFIX} \
-		-DBUILD_EXAMPLES=OFF -DBUILD_TESTS=OFF -DBUILD_DOC=OFF
+		-DBUILD_EXAMPLES=OFF -DBUILD_TESTS=OFF -DTESTS_USE_VALGRIND=OFF -DBUILD_DOC=OFF
 	make -j$(nproc) package
 	mv * /opt/"${version_name}"
 	cd ..

--- a/utils/docker/images/prepare-pmemkv.sh
+++ b/utils/docker/images/prepare-pmemkv.sh
@@ -24,18 +24,6 @@ fi
 # master: Merge pull request #991 from lukaszstolarczuk/update-dockers; 05.07.2021
 current_pmemkv_version="fd0f0f20989b1d8c75f54f3151542475a7da37d0"
 
-# stable-1.0: 1.0.3 release; 06.10.2020
-stable_1_pmemkv_version="77ae3ef23dc2b2db9c012dc343b125a785a0ffbc"
-
-# stable-1.1: 1.1 release; 31.01.2020
-stable_1_1_pmemkv_version="2f719305afb0f44103734851cfe825e1b1d73dbf"
-
-# stable-1.2: 1.2 release; 29.05.2020
-stable_1_2_pmemkv_version="1a9dccfd4b7c7437534838aaec7e5f3e38300dd6"
-
-# stable-1.3: 1.3 release; 02.10.2020
-stable_1_3_pmemkv_version="6f79229fd195310f4a45321e86e312e358fe481a"
-
 # stable-1.4: 1.4 release; 15.02.2021
 stable_1_4_pmemkv_version="ecb8fd65c5b07ed002d1018418ef809ab50d4e18"
 
@@ -59,10 +47,6 @@ git clone https://github.com/pmem/pmemkv
 cd pmemkv
 
 prepare_pmemkv "${current_pmemkv_version}" "pmemkv-master"
-prepare_pmemkv "${stable_1_pmemkv_version}" "pmemkv-stable-1.0"
-prepare_pmemkv "${stable_1_1_pmemkv_version}" "pmemkv-stable-1.1"
-prepare_pmemkv "${stable_1_2_pmemkv_version}" "pmemkv-stable-1.2"
-prepare_pmemkv "${stable_1_3_pmemkv_version}" "pmemkv-stable-1.3"
 prepare_pmemkv "${stable_1_4_pmemkv_version}" "pmemkv-stable-1.4"
 
 cd ..

--- a/utils/docker/run-build.sh
+++ b/utils/docker/run-build.sh
@@ -30,6 +30,7 @@ echo "### Verifying execution of examples"
 echo "###########################################################"
 cd examples
 run_example StringExample
+run_standalone_example StringExample
 run_example ByteBufferExample
 run_example MixedTypesExample
 run_example IteratorExample

--- a/utils/docker/run-maven-example.sh
+++ b/utils/docker/run-maven-example.sh
@@ -20,7 +20,7 @@ cd ${WORKDIR}/examples
 
 # pmemkv package in maven repository has a bit different name
 # and there may be different version available.
-mvn package -Dpmemkv.packageName=pmemkv-root -Dpmemkv.packageVersion=1.2.0 -e ${PMEMKV_MVN_PARAMS}
+mvn package -Dpmemkv.packageName=pmemkv-root -Dpmemkv.packageVersion=1.2.0 -e ${MVN_PARAMS}
 
 echo
 echo "#############################################################"


### PR DESCRIPTION
- we need newer Ubuntu for testing maven job in CI, because we require now pmemkv-1.4
- bump the dependencies
- cleanup the dead code in utils

// the maven job was tested on my fork: https://github.com/lukaszstolarczuk/pmemkv-java/runs/3000311737?check_suite_focus=true

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmemkv-java/178)
<!-- Reviewable:end -->
